### PR TITLE
Improve file walker, license parsing, and add .svx support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ licensor add "src/**/*.py"
 licensor check "src/**/*.py"
 ```
 
-Use `-c` to point at a different config path, `--ignore` to exclude globs, and `--verbose` for debug logging.
+Use `-c` to point at a different config path, `--ignore` to exclude globs, `--respect-gitignore` / `--no-respect-gitignore` to control `.gitignore` filtering (on by default), and `--verbose` for debug logging.
 
 ## Supported extensions
 
@@ -51,7 +51,7 @@ Use `-c` to point at a different config path, `--ignore` to exclude globs, and `
   `h`, `hpp`, `cs`, `swift`, `dart`, `php`
 - Astro (HTML comments after frontmatter): `astro`
 - MDX (JSX comments after frontmatter): `mdx`
-- HTML-like block comments: `html`, `htm`, `xhtml`, `xml`, `svg`, `svelte`, `svx`, `md`, `vue`, `hbs`, `handlebars`, `mustache`
+- HTML-like block comments: `html`, `htm`, `xhtml`, `xml`, `svg`, `svelte`, `md`, `vue`, `hbs`, `handlebars`, `mustache`
 - CSS-like block comments: `css`, `scss`, `sass`, `less`
 - CMD line comments: `cmd`
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Use `-c` to point at a different config path, `--ignore` to exclude globs, and `
   `h`, `hpp`, `cs`, `swift`, `dart`, `php`
 - Astro (HTML comments after frontmatter): `astro`
 - MDX (JSX comments after frontmatter): `mdx`
-- HTML-like block comments: `html`, `htm`, `xhtml`, `xml`, `svg`, `svelte`, `md`, `vue`, `hbs`, `handlebars`, `mustache`
+- HTML-like block comments: `html`, `htm`, `xhtml`, `xml`, `svg`, `svelte`, `svx`, `md`, `vue`, `hbs`, `handlebars`, `mustache`
 - CSS-like block comments: `css`, `scss`, `sass`, `less`
 - CMD line comments: `cmd`
 

--- a/src/main/scala/CliUtils.scala
+++ b/src/main/scala/CliUtils.scala
@@ -10,75 +10,55 @@ import java.nio.file.Paths
 
 import config.LicensingConfig
 
-/** Utility helpers for CLI file handling and config loading.
-  *
-  * Provides cross-platform file collection using glob patterns and configuration loading with error
-  * handling. Uses [[FileWalker]] for safe directory traversal and Java NIO's PathMatcher for glob
-  * matching.
-  *
-  * ==Supported Glob Patterns==
-  * Patterns use Java NIO glob syntax:
-  *   - `*` matches any characters within a single path segment (doesn't cross `/`)
-  *   - `**` matches any characters across multiple path segments
-  *   - `?` matches exactly one character
-  *   - `[abc]` matches one character from the set
-  *   - `{a,b}` matches either pattern a or b
-  *
-  * All patterns are matched against paths normalized with forward slashes.
-  */
+/** Utility helpers for CLI file handling and config loading. */
 object CliUtils:
 
-  /** Collect input files based on glob patterns and ignore globs.
+  /** Collect input files based on glob patterns and ignore rules.
+    *
+    * Ignore rules are merged from the config file, CLI flags, and (by default) `.gitignore` files
+    * encountered while walking.
     *
     * @param globs
-    *   input glob patterns or direct file paths
+    *   input glob patterns or direct file/directory paths
     * @param ignoreGlobs
-    *   glob patterns to exclude from results
+    *   glob patterns to exclude (config + CLI, merged by caller)
     * @param baseDir
-    *   base directory for resolving relative paths and walking for glob matches
-    * @return
-    *   distinct matching files that are not excluded by ignore patterns
+    *   base directory for resolving relative paths
+    * @param respectGitignore
+    *   when true, apply `.gitignore` rules during directory walks
     */
   def collectFiles(
       globs: Vector[String],
       ignoreGlobs: Vector[String],
-      baseDir: os.Path
+      baseDir: os.Path,
+      respectGitignore: Boolean = true
   ): Vector[os.Path] =
     val logger = org.slf4j.LoggerFactory.getLogger("xyz.nicebots.CliUtils")
     logger.debug(s"Base directory: $baseDir")
     logger.debug(s"Input globs: ${globs.mkString(", ")}")
     logger.debug(s"Ignore globs: ${ignoreGlobs.mkString(", ")}")
+    logger.debug(s"Respect gitignore: $respectGitignore")
 
-    val candidates = expandPatterns(globs, baseDir)
-    logger.debug(s"Candidates: ${candidates.map(_.relativeTo(baseDir)).mkString(", ")}")
+    val ignoreMatchers = ignoreGlobs.map(normalizePattern).map(createPathMatcher)
+    val candidates     = expandPatterns(globs, baseDir, respectGitignore)
+    val result         =
+      if ignoreMatchers.isEmpty then candidates
+      else candidates.filterNot(path => matchesAny(baseDir, path, ignoreMatchers))
 
-    if ignoreGlobs.isEmpty then candidates
-    else
-      val ignored = expandPatterns(ignoreGlobs, baseDir).toSet
-      val result  = candidates.filterNot(ignored.contains)
-      logger.debug(s"After ignores: ${result.map(_.relativeTo(baseDir)).mkString(", ")}")
-      result
+    logger.debug(s"Matched files: ${result.map(_.relativeTo(baseDir)).mkString(", ")}")
+    result
 
-  /** Expand a list of patterns (globs or paths) into matching files.
-    *
-    * @param patterns
-    *   glob patterns or direct file/directory paths
-    * @param baseDir
-    *   base directory for resolving relative paths and walking
-    * @return
-    *   all files matching the patterns
-    */
-  private def expandPatterns(patterns: Vector[String], baseDir: os.Path): Vector[os.Path] =
-    val normalized = patterns.map { pattern =>
-      val withoutPrefix = if pattern.startsWith("./") then pattern.drop(2) else pattern
-      withoutPrefix.replace('\\', '/')
-    }
+  private def expandPatterns(
+      patterns: Vector[String],
+      baseDir: os.Path,
+      respectGitignore: Boolean
+  ): Vector[os.Path] =
+    val normalized = patterns.map(normalizePattern)
 
     val (globPatterns, directPaths) = normalized.partition(isGlobPattern)
 
     val directMatches = directPaths.flatMap { p =>
-      val resolved = resolvePath(p, baseDir)
-      FileWalker.listFiles(resolved)
+      FileWalker.listFiles(resolvePath(p, baseDir), respectGitignore = respectGitignore)
     }
 
     val globMatchers = globPatterns.map(createPathMatcher)
@@ -87,25 +67,11 @@ object CliUtils:
       else
         val extensionHints = FileWalker.extensionHintsFromGlobs(globPatterns)
         FileWalker
-          .listFiles(baseDir, extensionHints)
+          .listFiles(baseDir, extensionHints, respectGitignore)
           .filter(path => matchesAny(baseDir, path, globMatchers))
 
     (directMatches ++ globMatches).distinct
 
-  /** Load configuration from a file, exiting the process on error.
-    *
-    * Resolves the config path relative to `baseDir` if not absolute, then attempts to parse it as a
-    * [[LicensingConfig]]. Logs an error and exits with code 1 if the file is missing or malformed.
-    *
-    * @param path
-    *   config file path (absolute or relative to `baseDir`)
-    * @param baseDir
-    *   base directory for resolving relative paths
-    * @param logger
-    *   logger used for error messages
-    * @return
-    *   parsed licensing config (never returns on error, calls `sys.exit(1)`)
-    */
   def loadConfigOrExit(path: String, baseDir: os.Path, logger: Logger): LicensingConfig =
     val configPath = resolvePath(path, baseDir)
     if !os.isFile(configPath) then
@@ -117,58 +83,25 @@ object CliUtils:
         sys.exit(1)
       case Right(cfg) => cfg
 
-  /** Resolve a path string relative to a base directory.
-    *
-    * @param path
-    *   input path string (absolute or relative)
-    * @param baseDir
-    *   base directory for resolving relative paths
-    * @return
-    *   resolved absolute path
-    */
   private def resolvePath(path: String, baseDir: os.Path): os.Path =
-    val parsed = os.FilePath(path)
-    parsed match
+    os.FilePath(path) match
       case p: os.Path    => p
       case p: os.RelPath => baseDir / p
       case p: os.SubPath => baseDir / p
 
-  /** Create a PathMatcher from a glob pattern.
-    *
-    * @param pattern
-    *   glob pattern using Java NIO glob syntax
-    * @return
-    *   compiled PathMatcher
-    */
+  private def normalizePattern(pattern: String): String =
+    val withoutPrefix = if pattern.startsWith("./") then pattern.drop(2) else pattern
+    withoutPrefix.replace('\\', '/')
+
   private def createPathMatcher(pattern: String): PathMatcher =
     FileSystems.getDefault.getPathMatcher(s"glob:$pattern")
 
-  /** Check if a path matches any of the given patterns.
-    *
-    * Path is normalized to forward slashes via os-lib before matching.
-    *
-    * @param base
-    *   base directory for relativization
-    * @param path
-    *   absolute path to check
-    * @param matchers
-    *   compiled PathMatchers
-    * @return
-    *   true if the path matches any pattern
-    */
   private def matchesAny(
       base: os.Path,
       path: os.Path,
       matchers: Vector[PathMatcher]
   ): Boolean =
-    val relPathStr = path.relativeTo(base).toString
-    val relPath    = Paths.get(relPathStr)
-    val result     = matchers.exists(_.matches(relPath))
-    if result then
-      org.slf4j.LoggerFactory
-        .getLogger("xyz.nicebots.CliUtils")
-        .debug(s"Path '$relPathStr' matched by a pattern")
-    result
+    matchers.exists(_.matches(Paths.get(path.relativeTo(base).toString)))
 
   private def isGlobPattern(s: String): Boolean =
     s.exists(c => c == '*' || c == '?' || c == '[' || c == '{')

--- a/src/main/scala/CliUtils.scala
+++ b/src/main/scala/CliUtils.scala
@@ -13,7 +13,8 @@ import config.LicensingConfig
 /** Utility helpers for CLI file handling and config loading.
   *
   * Provides cross-platform file collection using glob patterns and configuration loading with error
-  * handling. Uses `os-lib` for path normalization and Java NIO's PathMatcher for glob matching.
+  * handling. Uses [[FileWalker]] for safe directory traversal and Java NIO's PathMatcher for glob
+  * matching.
   *
   * ==Supported Glob Patterns==
   * Patterns use Java NIO glob syntax:
@@ -25,7 +26,7 @@ import config.LicensingConfig
   *
   * All patterns are matched against paths normalized with forward slashes.
   */
-object CliUtils {
+object CliUtils:
 
   /** Collect input files based on glob patterns and ignore globs.
     *
@@ -77,20 +78,17 @@ object CliUtils {
 
     val directMatches = directPaths.flatMap { p =>
       val resolved = resolvePath(p, baseDir)
-      if os.isFile(resolved) then Vector(resolved)
-      else if os.isDir(resolved) then os.walk(resolved).filter(os.isFile).toVector
-      else Vector.empty
+      FileWalker.listFiles(resolved)
     }
 
     val globMatchers = globPatterns.map(createPathMatcher)
     val globMatches  =
       if globMatchers.isEmpty then Vector.empty
       else
-        os.walk(baseDir)
-          .filter { path =>
-            os.isFile(path) && matchesAny(baseDir, path, globMatchers)
-          }
-          .toVector
+        val extensionHints = FileWalker.extensionHintsFromGlobs(globPatterns)
+        FileWalker
+          .listFiles(baseDir, extensionHints)
+          .filter(path => matchesAny(baseDir, path, globMatchers))
 
     (directMatches ++ globMatches).distinct
 
@@ -174,4 +172,3 @@ object CliUtils {
 
   private def isGlobPattern(s: String): Boolean =
     s.exists(c => c == '*' || c == '?' || c == '[' || c == '{')
-}

--- a/src/main/scala/CliUtils.scala
+++ b/src/main/scala/CliUtils.scala
@@ -58,7 +58,11 @@ object CliUtils:
     val (globPatterns, directPaths) = normalized.partition(isGlobPattern)
 
     val directMatches = directPaths.flatMap { p =>
-      FileWalker.listFiles(resolvePath(p, baseDir), respectGitignore = respectGitignore)
+      FileWalker.listFiles(
+        resolvePath(p, baseDir),
+        respectGitignore = respectGitignore,
+        gitignoreRoot = Some(baseDir)
+      )
     }
 
     val globMatchers = globPatterns.map(createPathMatcher)
@@ -67,7 +71,12 @@ object CliUtils:
       else
         val extensionHints = FileWalker.extensionHintsFromGlobs(globPatterns)
         FileWalker
-          .listFiles(baseDir, extensionHints, respectGitignore)
+          .listFiles(
+            baseDir,
+            extensionHints,
+            respectGitignore,
+            gitignoreRoot = Some(baseDir)
+          )
           .filter(path => matchesAny(baseDir, path, globMatchers))
 
     (directMatches ++ globMatches).distinct

--- a/src/main/scala/FileWalker.scala
+++ b/src/main/scala/FileWalker.scala
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+// Copyright: 2026 NiceBots.xyz
+package xyz.nicebots
+
+import java.io.IOException
+import java.nio.file.*
+import java.nio.file.attribute.BasicFileAttributes
+
+/** Safe, performance-oriented directory traversal for CLI file collection.
+  *
+  * Skips common VCS and dependency cache directories, does not follow symbolic links, and
+  * optionally filters by file extension before glob matching.
+  */
+object FileWalker:
+
+  /** Directory names skipped during traversal (exact match on the final path segment). */
+  val DefaultSkipDirNames: Set[String] = Set(
+    ".git",
+    ".svn",
+    ".hg",
+    ".bzr",
+    "node_modules",
+    "target",
+    "dist",
+    "build",
+    "out",
+    ".gradle",
+    ".m2",
+    ".ivy2",
+    ".coursier",
+    "__pycache__",
+    ".pytest_cache",
+    ".tox",
+    ".venv",
+    "venv",
+    ".idea",
+    ".cursor",
+    ".next",
+    ".nuxt",
+    ".svelte-kit",
+    ".turbo",
+    "coverage"
+  )
+
+  /** Collect all regular files under `root`, applying optional extension prefiltering.
+    *
+    * @param root
+    *   directory to walk
+    * @param extensionHints
+    *   when non-empty, only files whose extension (lowercase, no dot) is in this set are returned
+    * @param skipDirNames
+    *   directory names to prune from the walk
+    * @return
+    *   files discovered under `root` (not including `root` itself)
+    */
+  def listFiles(
+      root: os.Path,
+      extensionHints: Set[String] = Set.empty,
+      skipDirNames: Set[String] = DefaultSkipDirNames
+  ): Vector[os.Path] =
+    if !os.exists(root) then Vector.empty
+    else if os.isFile(root) then Vector(root)
+    else
+      val result  = Vector.newBuilder[os.Path]
+      val visitor = new SimpleFileVisitor[Path]:
+        override def preVisitDirectory(
+            dir: Path,
+            attrs: BasicFileAttributes
+        ): FileVisitResult =
+          if attrs.isSymbolicLink then FileVisitResult.SKIP_SUBTREE
+          else if dir == root.toNIO then super.preVisitDirectory(dir, attrs)
+          else if skipDirNames.contains(dir.getFileName.toString) then FileVisitResult.SKIP_SUBTREE
+          else super.preVisitDirectory(dir, attrs)
+
+        override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult =
+          if attrs.isRegularFile && !attrs.isSymbolicLink then
+            val path = os.Path(file)
+            if extensionHints.isEmpty || matchesExtensionHint(path, extensionHints) then
+              result += path
+          FileVisitResult.CONTINUE
+
+        override def visitFileFailed(file: Path, exc: IOException): FileVisitResult =
+          FileVisitResult.CONTINUE
+
+      try Files.walkFileTree(root.toNIO, visitor)
+      catch case _: IOException => ()
+      result.result()
+
+  /** Infer lowercase extensions from recursive glob patterns ending in a dotted extension. */
+  def extensionHintsFromGlobs(globs: Vector[String]): Set[String] =
+    globs.flatMap(extensionFromGlob).map(_.toLowerCase).toSet
+
+  private val globExtensionPattern = ".*\\*\\.([A-Za-z0-9]+)".r
+
+  private def extensionFromGlob(glob: String): Option[String] =
+    val normalized = glob.replace('\\', '/')
+    globExtensionPattern.findFirstMatchIn(normalized).map(_.group(1))
+
+  private def matchesExtensionHint(path: os.Path, hints: Set[String]): Boolean =
+    extensionOf(path) match
+      case ""  => false
+      case ext => hints.contains(ext)
+
+  private def extensionOf(path: os.Path): String =
+    val name     = path.last
+    val dotIndex = name.lastIndexOf('.')
+    if dotIndex < 0 || dotIndex == name.length - 1 then ""
+    else name.substring(dotIndex + 1).toLowerCase

--- a/src/main/scala/FileWalker.scala
+++ b/src/main/scala/FileWalker.scala
@@ -3,7 +3,7 @@
 package xyz.nicebots
 
 import java.io.IOException
-import java.nio.file.*
+import java.nio.file._
 import java.nio.file.attribute.BasicFileAttributes
 
 /** Safe directory traversal for CLI file collection. */

--- a/src/main/scala/FileWalker.scala
+++ b/src/main/scala/FileWalker.scala
@@ -6,14 +6,9 @@ import java.io.IOException
 import java.nio.file.*
 import java.nio.file.attribute.BasicFileAttributes
 
-/** Safe, performance-oriented directory traversal for CLI file collection.
-  *
-  * Skips common VCS and dependency cache directories, does not follow symbolic links, and
-  * optionally filters by file extension before glob matching.
-  */
+/** Safe directory traversal for CLI file collection. */
 object FileWalker:
 
-  /** Directory names skipped during traversal (exact match on the final path segment). */
   val DefaultSkipDirNames: Set[String] = Set(
     ".git",
     ".svn",
@@ -42,17 +37,6 @@ object FileWalker:
     "coverage"
   )
 
-  /** Collect all regular files under `root`, applying optional extension prefiltering.
-    *
-    * @param root
-    *   directory to walk
-    * @param extensionHints
-    *   when non-empty, only files whose extension (lowercase, no dot) is in this set are returned
-    * @param skipDirNames
-    *   directory names to prune from the walk
-    * @return
-    *   files discovered under `root` (not including `root` itself)
-    */
   def listFiles(
       root: os.Path,
       extensionHints: Set[String] = Set.empty,
@@ -84,17 +68,27 @@ object FileWalker:
 
       try Files.walkFileTree(root.toNIO, visitor)
       catch case _: IOException => ()
-      result.result()
+      result
+        .result()
+        .filterNot(path => hasSkippedSegment(root, path, skipDirNames))
 
-  /** Infer lowercase extensions from recursive glob patterns ending in a dotted extension. */
   def extensionHintsFromGlobs(globs: Vector[String]): Set[String] =
     globs.flatMap(extensionFromGlob).map(_.toLowerCase).toSet
+
+  private def hasSkippedSegment(
+      root: os.Path,
+      path: os.Path,
+      skipDirNames: Set[String]
+  ): Boolean =
+    val segments =
+      try path.relativeTo(root).segments
+      catch case _: Throwable => Vector.empty[String]
+    segments.exists(skipDirNames.contains)
 
   private val globExtensionPattern = ".*\\*\\.([A-Za-z0-9]+)".r
 
   private def extensionFromGlob(glob: String): Option[String] =
-    val normalized = glob.replace('\\', '/')
-    globExtensionPattern.findFirstMatchIn(normalized).map(_.group(1))
+    globExtensionPattern.findFirstMatchIn(glob.replace('\\', '/')).map(_.group(1))
 
   private def matchesExtensionHint(path: os.Path, hints: Set[String]): Boolean =
     extensionOf(path) match

--- a/src/main/scala/FileWalker.scala
+++ b/src/main/scala/FileWalker.scala
@@ -24,8 +24,8 @@ object FileWalker:
     else
       val ignoreRoot = gitignoreRoot.getOrElse(root)
       val gitignore  = if respectGitignore then Some(GitignoreMatcher(ignoreRoot)) else None
-      val result    = Vector.newBuilder[os.Path]
-      val visitor   = new SimpleFileVisitor[Path]:
+      val result     = Vector.newBuilder[os.Path]
+      val visitor    = new SimpleFileVisitor[Path]:
         override def preVisitDirectory(
             dir: Path,
             attrs: BasicFileAttributes

--- a/src/main/scala/FileWalker.scala
+++ b/src/main/scala/FileWalker.scala
@@ -6,61 +6,42 @@ import java.io.IOException
 import java.nio.file._
 import java.nio.file.attribute.BasicFileAttributes
 
-/** Safe directory traversal for CLI file collection. */
+/** Directory traversal for CLI file collection.
+  *
+  * By default respects `.gitignore` files discovered while walking. Symbolic links are never
+  * followed.
+  */
 object FileWalker:
-
-  val DefaultSkipDirNames: Set[String] = Set(
-    ".git",
-    ".svn",
-    ".hg",
-    ".bzr",
-    "node_modules",
-    "target",
-    "dist",
-    "build",
-    "out",
-    ".gradle",
-    ".m2",
-    ".ivy2",
-    ".coursier",
-    "__pycache__",
-    ".pytest_cache",
-    ".tox",
-    ".venv",
-    "venv",
-    ".idea",
-    ".cursor",
-    ".next",
-    ".nuxt",
-    ".svelte-kit",
-    ".turbo",
-    "coverage"
-  )
 
   def listFiles(
       root: os.Path,
       extensionHints: Set[String] = Set.empty,
-      skipDirNames: Set[String] = DefaultSkipDirNames
+      respectGitignore: Boolean = true
   ): Vector[os.Path] =
     if !os.exists(root) then Vector.empty
     else if os.isFile(root) then Vector(root)
     else
-      val result  = Vector.newBuilder[os.Path]
-      val visitor = new SimpleFileVisitor[Path]:
+      val gitignore = if respectGitignore then Some(GitignoreMatcher(root)) else None
+      val result    = Vector.newBuilder[os.Path]
+      val visitor   = new SimpleFileVisitor[Path]:
         override def preVisitDirectory(
             dir: Path,
             attrs: BasicFileAttributes
         ): FileVisitResult =
           if attrs.isSymbolicLink then FileVisitResult.SKIP_SUBTREE
-          else if dir == root.toNIO then super.preVisitDirectory(dir, attrs)
-          else if skipDirNames.contains(dir.getFileName.toString) then FileVisitResult.SKIP_SUBTREE
-          else super.preVisitDirectory(dir, attrs)
+          else
+            val path = os.Path(dir)
+            gitignore.foreach(_.enterDirectory(path))
+            if gitignore.exists(_.isIgnored(path, isDirectory = true)) then
+              FileVisitResult.SKIP_SUBTREE
+            else super.preVisitDirectory(dir, attrs)
 
         override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult =
           if attrs.isRegularFile && !attrs.isSymbolicLink then
-            val path = os.Path(file)
-            if extensionHints.isEmpty || matchesExtensionHint(path, extensionHints) then
-              result += path
+            val path    = os.Path(file)
+            val ignored = gitignore.exists(_.isIgnored(path, isDirectory = false))
+            val extOk   = extensionHints.isEmpty || matchesExtensionHint(path, extensionHints)
+            if !ignored && extOk then result += path
           FileVisitResult.CONTINUE
 
         override def visitFileFailed(file: Path, exc: IOException): FileVisitResult =
@@ -68,22 +49,10 @@ object FileWalker:
 
       try Files.walkFileTree(root.toNIO, visitor)
       catch case _: IOException => ()
-      result
-        .result()
-        .filterNot(path => hasSkippedSegment(root, path, skipDirNames))
+      result.result()
 
   def extensionHintsFromGlobs(globs: Vector[String]): Set[String] =
     globs.flatMap(extensionFromGlob).map(_.toLowerCase).toSet
-
-  private def hasSkippedSegment(
-      root: os.Path,
-      path: os.Path,
-      skipDirNames: Set[String]
-  ): Boolean =
-    val segments =
-      try path.relativeTo(root).segments
-      catch case _: Throwable => Vector.empty[String]
-    segments.exists(skipDirNames.contains)
 
   private val globExtensionPattern = ".*\\*\\.([A-Za-z0-9]+)".r
 

--- a/src/main/scala/FileWalker.scala
+++ b/src/main/scala/FileWalker.scala
@@ -16,12 +16,14 @@ object FileWalker:
   def listFiles(
       root: os.Path,
       extensionHints: Set[String] = Set.empty,
-      respectGitignore: Boolean = true
+      respectGitignore: Boolean = true,
+      gitignoreRoot: Option[os.Path] = None
   ): Vector[os.Path] =
     if !os.exists(root) then Vector.empty
     else if os.isFile(root) then Vector(root)
     else
-      val gitignore = if respectGitignore then Some(GitignoreMatcher(root)) else None
+      val ignoreRoot = gitignoreRoot.getOrElse(root)
+      val gitignore  = if respectGitignore then Some(GitignoreMatcher(ignoreRoot)) else None
       val result    = Vector.newBuilder[os.Path]
       val visitor   = new SimpleFileVisitor[Path]:
         override def preVisitDirectory(

--- a/src/main/scala/FileWalker.scala
+++ b/src/main/scala/FileWalker.scala
@@ -20,7 +20,9 @@ object FileWalker:
       gitignoreRoot: Option[os.Path] = None
   ): Vector[os.Path] =
     if !os.exists(root) then Vector.empty
-    else if os.isFile(root) then Vector(root)
+    else if os.isFile(root) then
+      if os.isLink(root) then Vector.empty
+      else Vector(root)
     else
       val ignoreRoot = gitignoreRoot.getOrElse(root)
       val gitignore  = if respectGitignore then Some(GitignoreMatcher(ignoreRoot)) else None

--- a/src/main/scala/GitignoreMatcher.scala
+++ b/src/main/scala/GitignoreMatcher.scala
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+// Copyright: 2026 NiceBots.xyz
+package xyz.nicebots
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
+/** Gitignore pattern matching for directory walks.
+  *
+  * Loads `.gitignore` files while descending the tree. Patterns from each ancestor directory apply,
+  * and the last matching rule wins (including negated rules).
+  */
+final class GitignoreMatcher private (root: os.Path):
+
+  private val rulesByDir =
+    scala.collection.mutable.Map.empty[os.Path, Vector[GitignoreMatcher.Rule]]
+
+  def enterDirectory(dir: os.Path): Unit =
+    val gitignore = dir / ".gitignore"
+    if os.isFile(gitignore) then
+      rulesByDir(dir) = GitignoreMatcher.parseRules(
+        Files.readString(gitignore.toNIO, StandardCharsets.UTF_8)
+      )
+
+  def isIgnored(path: os.Path, isDirectory: Boolean): Boolean =
+    val relative =
+      try GitignoreMatcher.normalizeRelative(path.relativeTo(root).toString)
+      catch case _: Throwable => return false
+
+    val segments =
+      try path.relativeTo(root).segments
+      catch case _: Throwable => Vector.empty[String]
+
+    var ignored = false
+    var current = root
+
+    def applyDirRules(dir: os.Path): Unit =
+      rulesByDir.get(dir).foreach { rules =>
+        rules.foreach { rule =>
+          if GitignoreMatcher.ruleMatches(rule, relative, isDirectory) then ignored = !rule.negated
+        }
+      }
+
+    applyDirRules(root)
+    segments.foreach { seg =>
+      current = current / seg
+      applyDirRules(current)
+    }
+    ignored
+
+object GitignoreMatcher:
+
+  private case class Rule(
+      pattern: String,
+      negated: Boolean,
+      directoryOnly: Boolean,
+      anchored: Boolean
+  )
+
+  def apply(root: os.Path): GitignoreMatcher =
+    val matcher = new GitignoreMatcher(root)
+    matcher.enterDirectory(root)
+    matcher
+
+  private def normalizeRelative(path: String): String =
+    path.replace('\\', '/')
+
+  private def parseRules(content: String): Vector[Rule] =
+    content.linesIterator
+      .map(_.trim)
+      .filter(line => line.nonEmpty && !line.startsWith("#"))
+      .flatMap(parseLine)
+      .toVector
+
+  private def parseLine(line: String): Option[Rule] =
+    var text    = line
+    val negated = text.startsWith("!")
+    if negated then text = text.drop(1)
+    val dirOnly = text.endsWith("/")
+    if dirOnly then text = text.dropRight(1)
+    val anchored = text.startsWith("/")
+    if anchored then text = text.drop(1)
+    if text.isEmpty then None
+    else Some(Rule(text, negated, dirOnly, anchored))
+
+  private def ruleMatches(rule: Rule, relativePath: String, isDirectory: Boolean): Boolean =
+    if rule.directoryOnly then
+      val dir = rule.pattern
+      relativePath == dir || relativePath.startsWith(dir + "/") ||
+      relativePath.endsWith("/" + dir) || relativePath.contains("/" + dir + "/")
+    else
+      val target =
+        if rule.anchored then relativePath
+        else if rule.pattern.contains('/') then relativePath
+        else relativePath.substring(relativePath.lastIndexOf('/') + 1)
+      pathMatches(rule.pattern, target)
+
+  private def pathMatches(pattern: String, path: String): Boolean =
+    path.matches(gitignorePatternToRegex(pattern))
+
+  private def gitignorePatternToRegex(pattern: String): String =
+    val sb = new StringBuilder("^")
+    var i  = 0
+    while i < pattern.length do
+      pattern(i) match
+        case '*' =>
+          if i + 1 < pattern.length && pattern(i + 1) == '*' then
+            sb.append(".*")
+            i += 2
+            if i < pattern.length && pattern(i) == '/' then i += 1
+          else
+            sb.append("[^/]*")
+            i += 1
+        case '?' =>
+          sb.append("[^/]")
+          i += 1
+        case c if ".[]{}()+^$|\\".contains(c) =>
+          sb.append('\\').append(c)
+          i += 1
+        case c =>
+          sb.append(c)
+          i += 1
+    sb.append('$').result()

--- a/src/main/scala/GitignoreMatcher.scala
+++ b/src/main/scala/GitignoreMatcher.scala
@@ -36,8 +36,12 @@ final class GitignoreMatcher private (root: os.Path):
 
     def applyDirRules(dir: os.Path): Unit =
       rulesByDir.get(dir).foreach { rules =>
+        val relativeToDir =
+          try GitignoreMatcher.normalizeRelative(path.relativeTo(dir).toString)
+          catch case _: Throwable => return
         rules.foreach { rule =>
-          if GitignoreMatcher.ruleMatches(rule, relative, isDirectory) then ignored = !rule.negated
+          if GitignoreMatcher.ruleMatches(rule, relativeToDir, isDirectory) then
+            ignored = !rule.negated
         }
       }
 

--- a/src/main/scala/GitignoreMatcher.scala
+++ b/src/main/scala/GitignoreMatcher.scala
@@ -23,10 +23,6 @@ final class GitignoreMatcher private (root: os.Path):
       )
 
   def isIgnored(path: os.Path, isDirectory: Boolean): Boolean =
-    val relative =
-      try GitignoreMatcher.normalizeRelative(path.relativeTo(root).toString)
-      catch case _: Throwable => return false
-
     val segments =
       try path.relativeTo(root).segments
       catch case _: Throwable => Vector.empty[String]

--- a/src/main/scala/Licensing.scala
+++ b/src/main/scala/Licensing.scala
@@ -36,19 +36,9 @@ trait FileHandler:
     if checkLicense(fileDump, licenseText) == LicenseState.Missing then (rendered + fileDump, true)
     else (fileDump, false)
 
-  /** Check whether the file starts with the rendered license header.
-    *
-    * @param fileDump
-    *   full file contents
-    * @param licenseText
-    *   plain-text license content
-    * @return
-    *   true if the rendered header appears at the beginning of the file
-    */
-  private def hasLicense(fileDump: String, licenseText: String): Boolean =
-    val expectedFirst = generateLicense(licenseText).linesIterator.nextOption.getOrElse("")
-    val actualFirst   = fileDump.linesIterator.nextOption.getOrElse("")
-    actualFirst == expectedFirst
+  /** Check whether the file begins with the fully rendered license header block. */
+  private def hasRenderedHeader(fileDump: String, licenseText: String): Boolean =
+    fileDump.startsWith(generateLicense(licenseText))
 
   /** Detect another license header by scanning for external markers.
     *
@@ -64,7 +54,7 @@ trait FileHandler:
   private def hasExternal(
       fileDump: String,
       externalMarkers: Vector[String] = Vector("Copyright", "SPDX-License-Identifier"),
-      scanLines: Int = 3
+      scanLines: Int = 5
   ): Boolean =
     val headerLines = fileDump.linesIterator.take(scanLines).map(_.trim).toVector
     externalMarkers.exists(marker => headerLines.exists(_.contains(marker)))
@@ -82,6 +72,6 @@ trait FileHandler:
       fileDump: String,
       licenseText: String
   ): LicenseState =
-    if hasLicense(fileDump, licenseText) then LicenseState.Present
+    if hasRenderedHeader(fileDump, licenseText) then LicenseState.Present
     else if hasExternal(fileDump) then LicenseState.External
     else LicenseState.Missing

--- a/src/main/scala/LineParsing.scala
+++ b/src/main/scala/LineParsing.scala
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+// Copyright: 2026 NiceBots.xyz
+package xyz.nicebots
+
+/** Shared line-based parsing helpers for license header placement. */
+object LineParsing:
+
+  /** Split text into lines, preserving trailing empty segments and normalizing CRLF. */
+  def splitLines(text: String): Vector[String] =
+    text
+      .split("\n", -1)
+      .toVector
+      .map(line => if line.endsWith("\r") then line.dropRight(1) else line)
+
+  /** Index immediately after a YAML-style `---` frontmatter block, if present. */
+  def frontmatterInsertIndex(lines: Vector[String]): Int =
+    val markerIndexes = lines.zipWithIndex.collect {
+      case (line, idx) if line.trim == "---" || line.trim.startsWith("---") => idx
+    }
+    if markerIndexes.length >= 2 then markerIndexes(1) + 1 else 0
+
+  /** Advance `startAt` past consecutive blank lines. */
+  def skipBlankLines(lines: Vector[String], startAt: Int): Int =
+    var idx = startAt
+    while idx < lines.length && lines(idx).trim.isEmpty do idx += 1
+    idx
+
+  /** Detect external license markers in the first `scanLines` non-blank lines after `insertAt`. */
+  def hasExternalAt(
+      lines: Vector[String],
+      insertAt: Int,
+      externalMarkers: Vector[String] = Vector("Copyright", "SPDX-License-Identifier"),
+      scanLines: Int = 5
+  ): Boolean =
+    val headerLines =
+      lines.drop(insertAt).dropWhile(_.trim.isEmpty).take(scanLines).map(_.trim)
+    externalMarkers.exists(marker => headerLines.exists(_.contains(marker)))

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -172,15 +172,19 @@ object CheckCommand extends Command[CommonOptions]:
           skipped += 1
           logger.warn(s"Skipping unsupported file type: ${formatPath(ctx.baseDir, path)}")
         case Some(handler) =>
-          val fileDump = Files.readString(path.toNIO, StandardCharsets.UTF_8)
-          handler.checkLicense(fileDump, ctx.licenseText) match
-            case LicenseState.Present =>
-              logger.info(s"Present: ${formatPath(ctx.baseDir, path)}")
-            case LicenseState.External =>
-              logger.info(s"External: ${formatPath(ctx.baseDir, path)}")
-            case LicenseState.Missing =>
-              missing += 1
-              logger.warn(s"Missing: ${formatPath(ctx.baseDir, path)}")
+          TextFiles.readUtf8(path) match
+            case None =>
+              skipped += 1
+              logger.warn(s"Skipping non-text file: ${formatPath(ctx.baseDir, path)}")
+            case Some(fileDump) =>
+              handler.checkLicense(fileDump, ctx.licenseText) match
+                case LicenseState.Present =>
+                  logger.info(s"Present: ${formatPath(ctx.baseDir, path)}")
+                case LicenseState.External =>
+                  logger.info(s"External: ${formatPath(ctx.baseDir, path)}")
+                case LicenseState.Missing =>
+                  missing += 1
+                  logger.warn(s"Missing: ${formatPath(ctx.baseDir, path)}")
     }
 
     logger.info(s"Skipped: $skipped")

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -44,6 +44,9 @@ case class CommonOptions(
     config: String = "licensor-config.yaml",
     @HelpMessage("Glob to ignore (can be specified multiple times)")
     ignore: Vector[String] = Vector.empty,
+    @HelpMessage("Respect .gitignore patterns when collecting files (default: enabled)")
+    @Name("respect-gitignore")
+    respectGitignore: Option[Boolean] = Some(true),
     @HelpMessage("Enable verbose logging")
     verbose: Option[Boolean] = Some(false)
 ) extends BaseOptions
@@ -107,12 +110,16 @@ def setupCommand(
 
   val baseDir    = os.pwd
   val inputGlobs = args.all.toVector
-  val inputFiles = CliUtils.collectFiles(inputGlobs, opts.ignore, baseDir)
+
+  val config           = CliUtils.loadConfigOrExit(opts.config, baseDir, logger)
+  val mergedIgnores    = config.ignores ++ opts.ignore
+  val respectGitignore = opts.respectGitignore.getOrElse(true)
+  val inputFiles       =
+    CliUtils.collectFiles(inputGlobs, mergedIgnores, baseDir, respectGitignore)
   if inputFiles.isEmpty then
     logger.error("No input files matched.")
     sys.exit(1)
 
-  val config      = CliUtils.loadConfigOrExit(opts.config, baseDir, logger)
   val licenseText = LicensingConfig.toLicenseText(config)
 
   val handlerList = Seq(
@@ -172,19 +179,15 @@ object CheckCommand extends Command[CommonOptions]:
           skipped += 1
           logger.warn(s"Skipping unsupported file type: ${formatPath(ctx.baseDir, path)}")
         case Some(handler) =>
-          TextFiles.readUtf8(path) match
-            case None =>
-              skipped += 1
-              logger.warn(s"Skipping non-text file: ${formatPath(ctx.baseDir, path)}")
-            case Some(fileDump) =>
-              handler.checkLicense(fileDump, ctx.licenseText) match
-                case LicenseState.Present =>
-                  logger.info(s"Present: ${formatPath(ctx.baseDir, path)}")
-                case LicenseState.External =>
-                  logger.info(s"External: ${formatPath(ctx.baseDir, path)}")
-                case LicenseState.Missing =>
-                  missing += 1
-                  logger.warn(s"Missing: ${formatPath(ctx.baseDir, path)}")
+          val fileDump = Files.readString(path.toNIO, StandardCharsets.UTF_8)
+          handler.checkLicense(fileDump, ctx.licenseText) match
+            case LicenseState.Present =>
+              logger.info(s"Present: ${formatPath(ctx.baseDir, path)}")
+            case LicenseState.External =>
+              logger.info(s"External: ${formatPath(ctx.baseDir, path)}")
+            case LicenseState.Missing =>
+              missing += 1
+              logger.warn(s"Missing: ${formatPath(ctx.baseDir, path)}")
     }
 
     logger.info(s"Skipped: $skipped")

--- a/src/main/scala/TextFiles.scala
+++ b/src/main/scala/TextFiles.scala
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+// Copyright: 2026 NiceBots.xyz
+package xyz.nicebots
+
+import java.nio.charset.{CharsetDecoder, CodingErrorAction, StandardCharsets}
+import java.nio.file.Files
+
+/** Safe UTF-8 text file reads for license processing. */
+object TextFiles:
+
+  private val utf8Decoder: CharsetDecoder =
+    StandardCharsets.UTF_8
+      .newDecoder()
+      .onMalformedInput(CodingErrorAction.REPORT)
+      .onUnmappableCharacter(CodingErrorAction.REPORT)
+
+  /** Read a file as UTF-8 text when it decodes cleanly.
+    *
+    * @param path
+    *   file to read
+    * @return
+    *   decoded contents, or `None` for missing files, directories, or non-text/binary input
+    */
+  def readUtf8(path: os.Path): Option[String] =
+    if !os.isFile(path) then None
+    else
+      try
+        val bytes = Files.readAllBytes(path.toNIO)
+        if bytes.isEmpty then Some("")
+        else
+          val buffer = java.nio.ByteBuffer.wrap(bytes)
+          Some(utf8Decoder.decode(buffer).toString)
+      catch case _: Exception => None

--- a/src/main/scala/TextFiles.scala
+++ b/src/main/scala/TextFiles.scala
@@ -2,7 +2,9 @@
 // Copyright: 2026 NiceBots.xyz
 package xyz.nicebots
 
-import java.nio.charset.{CharsetDecoder, CodingErrorAction, StandardCharsets}
+import java.nio.charset.CharsetDecoder
+import java.nio.charset.CodingErrorAction
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
 /** Safe UTF-8 text file reads for license processing. */

--- a/src/main/scala/TextFiles.scala
+++ b/src/main/scala/TextFiles.scala
@@ -31,5 +31,6 @@ object TextFiles:
         if bytes.isEmpty then Some("")
         else
           val buffer = java.nio.ByteBuffer.wrap(bytes)
+          utf8Decoder.reset()
           Some(utf8Decoder.decode(buffer).toString)
       catch case _: Exception => None

--- a/src/main/scala/config/LicensingConfig.scala
+++ b/src/main/scala/config/LicensingConfig.scala
@@ -25,11 +25,14 @@ enum YearRange:
   *   copyright holder
   * @param years
   *   copyright year or year range
+  * @param ignores
+  *   glob patterns excluded when collecting files (merged with CLI `--ignore`)
   */
 case class LicensingConfig(
     spdxId: Option[String],
     holder: String,
-    years: YearRange
+    years: YearRange,
+    ignores: Vector[String] = Vector.empty
 )
 
 object LicensingConfig:

--- a/src/main/scala/config/LicensingConfig.scala
+++ b/src/main/scala/config/LicensingConfig.scala
@@ -101,11 +101,20 @@ object LicensingConfig:
 
     val yearValue = values.get("year")
     val years     = parseYears(yearValue)
+    val ignores   = parseIgnores(values.get("ignores"))
 
     for
-      h <- holder
-      y <- years
-    yield LicensingConfig(spdxId = spdxId, holder = h, years = y)
+      h  <- holder
+      y  <- years
+      ig <- ignores
+    yield LicensingConfig(spdxId = spdxId, holder = h, years = y, ignores = ig)
+
+  private def parseIgnores(value: Object): Either[String, Vector[String]] =
+    value match
+      case null           => Right(Vector.empty)
+      case list: JList[?] =>
+        Right(list.toArray.toVector.map(_.toString.trim).filter(_.nonEmpty))
+      case _ => Left("Expected 'ignores' to be a list of strings")
 
   /** Parse the optional year value into a YearRange.
     *

--- a/src/main/scala/handlers/AstroHandler.scala
+++ b/src/main/scala/handlers/AstroHandler.scala
@@ -3,83 +3,10 @@
 package xyz.nicebots
 package handlers
 
-import xyz.nicebots.FileHandler
-import xyz.nicebots.LicenseState
-
 /** Handles .astro files with frontmatter-aware HTML comment headers. */
-class AstroHandler extends FileHandler:
-  /** Supported file extensions.
-    *
-    * @return
-    *   extension set without dots
-    */
-  override def extensions: Set[String] =
-    Set(
-      "astro"
-    )
+class AstroHandler extends FrontmatterHandler:
+  override def extensions: Set[String] = Set("astro")
 
-  /** Render an HTML comment header.
-    *
-    * @param raw
-    *   plain-text license content
-    * @return
-    *   rendered header ending with a newline
-    */
   override def generateLicense(raw: String): String =
     val body = raw.linesIterator.mkString("\n")
     s"<!--\n$body\n-->\n"
-
-  /** Add a license header after frontmatter if present. */
-  override def addLicense(fileDump: String, licenseText: String): (String, Boolean) =
-    val rendered = generateLicense(licenseText)
-    if checkLicense(fileDump, licenseText) == LicenseState.Missing then
-      (insertAfterFrontmatter(fileDump, rendered), true)
-    else (fileDump, false)
-
-  /** Check for a license header after frontmatter if present. */
-  override def checkLicense(fileDump: String, licenseText: String): LicenseState =
-    val rendered      = generateLicense(licenseText)
-    val lines         = splitLines(fileDump)
-    val insertAt      = frontmatterInsertIndex(lines)
-    val expectedFirst = rendered.linesIterator.nextOption.getOrElse("")
-    val actualFirst   = lines.drop(insertAt).dropWhile(_.trim.isEmpty).headOption.getOrElse("")
-    if expectedFirst == actualFirst then LicenseState.Present
-    else if hasExternalAt(lines, insertAt) then LicenseState.External
-    else LicenseState.Missing
-
-  private def insertAfterFrontmatter(fileDump: String, rendered: String): String =
-    val lines           = splitLines(fileDump)
-    val insertAt        = frontmatterInsertIndex(lines)
-    val trimmedInsertAt = skipBlankLines(lines, insertAt)
-    val headerLines     = splitLines(rendered.stripSuffix("\n"))
-    val separator       = if insertAt > 0 then Vector("") else Vector.empty
-    val updatedLines    =
-      lines.patch(insertAt, separator ++ headerLines, trimmedInsertAt - insertAt)
-    updatedLines.mkString("\n")
-
-  private def frontmatterInsertIndex(lines: Vector[String]): Int =
-    val markerIndexes = lines.zipWithIndex.collect {
-      case (line, idx) if line.trim.startsWith("---") => idx
-    }
-    if markerIndexes.length >= 2 then markerIndexes(1) + 1 else 0
-
-  private def hasExternalAt(
-      lines: Vector[String],
-      insertAt: Int,
-      externalMarkers: Vector[String] = Vector("Copyright", "SPDX-License-Identifier"),
-      scanLines: Int = 3
-  ): Boolean =
-    val headerLines =
-      lines.drop(insertAt).dropWhile(_.trim.isEmpty).take(scanLines).map(_.trim)
-    externalMarkers.exists(marker => headerLines.exists(_.contains(marker)))
-
-  private def splitLines(text: String): Vector[String] =
-    text
-      .split("\n", -1)
-      .toVector
-      .map(line => if line.endsWith("\r") then line.dropRight(1) else line)
-
-  private def skipBlankLines(lines: Vector[String], startAt: Int): Int =
-    var idx = startAt
-    while idx < lines.length && lines(idx).trim.isEmpty do idx += 1
-    idx

--- a/src/main/scala/handlers/FrontmatterHandler.scala
+++ b/src/main/scala/handlers/FrontmatterHandler.scala
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+// Copyright: 2026 NiceBots.xyz
+package xyz.nicebots
+package handlers
+
+import xyz.nicebots.{FileHandler, LicenseState, LineParsing}
+
+/** Base handler for formats that place license headers after optional YAML frontmatter. */
+abstract class FrontmatterHandler extends FileHandler:
+
+  override def addLicense(fileDump: String, licenseText: String): (String, Boolean) =
+    val rendered = generateLicense(licenseText)
+    if checkLicense(fileDump, licenseText) == LicenseState.Missing then
+      (insertAfterFrontmatter(fileDump, rendered), true)
+    else (fileDump, false)
+
+  override def checkLicense(fileDump: String, licenseText: String): LicenseState =
+    val rendered = generateLicense(licenseText)
+    val lines    = LineParsing.splitLines(fileDump)
+    val insertAt = LineParsing.frontmatterInsertIndex(lines)
+    if hasRenderedHeader(lines, insertAt, rendered) then LicenseState.Present
+    else if LineParsing.hasExternalAt(lines, insertAt) then LicenseState.External
+    else LicenseState.Missing
+
+  private def insertAfterFrontmatter(fileDump: String, rendered: String): String =
+    val lines           = LineParsing.splitLines(fileDump)
+    val insertAt        = LineParsing.frontmatterInsertIndex(lines)
+    val trimmedInsertAt = LineParsing.skipBlankLines(lines, insertAt)
+    val headerLines     = LineParsing.splitLines(rendered.stripSuffix("\n"))
+    val separator       = if insertAt > 0 then Vector("") else Vector.empty
+    val updatedLines    =
+      lines.patch(insertAt, separator ++ headerLines, trimmedInsertAt - insertAt)
+    updatedLines.mkString("\n")
+
+  private def hasRenderedHeader(
+      lines: Vector[String],
+      insertAt: Int,
+      rendered: String
+  ): Boolean =
+    val contentStart = LineParsing.skipBlankLines(lines, insertAt)
+    val headerLines  = LineParsing.splitLines(rendered.stripSuffix("\n"))
+    val fileHeader   = lines.slice(contentStart, contentStart + headerLines.length)
+    fileHeader == headerLines

--- a/src/main/scala/handlers/FrontmatterHandler.scala
+++ b/src/main/scala/handlers/FrontmatterHandler.scala
@@ -3,7 +3,9 @@
 package xyz.nicebots
 package handlers
 
-import xyz.nicebots.{FileHandler, LicenseState, LineParsing}
+import xyz.nicebots.FileHandler
+import xyz.nicebots.LicenseState
+import xyz.nicebots.LineParsing
 
 /** Base handler for formats that place license headers after optional YAML frontmatter. */
 abstract class FrontmatterHandler extends FileHandler:

--- a/src/main/scala/handlers/HtmlHandler.scala
+++ b/src/main/scala/handlers/HtmlHandler.scala
@@ -20,6 +20,7 @@ class HtmlHandler extends FileHandler:
       "xml",
       "svg",
       "svelte",
+      "svx",
       "md",
       "vue",
       "hbs",

--- a/src/main/scala/handlers/MdxHandler.scala
+++ b/src/main/scala/handlers/MdxHandler.scala
@@ -3,83 +3,10 @@
 package xyz.nicebots
 package handlers
 
-import xyz.nicebots.FileHandler
-import xyz.nicebots.LicenseState
-
 /** Handles .mdx files with frontmatter-aware JSX comment headers. */
-class MdxHandler extends FileHandler:
-  /** Supported file extensions.
-    *
-    * @return
-    *   extension set without dots
-    */
-  override def extensions: Set[String] =
-    Set(
-      "mdx"
-    )
+class MdxHandler extends FrontmatterHandler:
+  override def extensions: Set[String] = Set("mdx")
 
-  /** Render a JSX comment header.
-    *
-    * @param raw
-    *   plain-text license content
-    * @return
-    *   rendered header ending with a newline
-    */
   override def generateLicense(raw: String): String =
     val body = raw.linesIterator.mkString("\n")
     s"{/*\n$body\n*/}\n"
-
-  /** Add a license header after frontmatter if present. */
-  override def addLicense(fileDump: String, licenseText: String): (String, Boolean) =
-    val rendered = generateLicense(licenseText)
-    if checkLicense(fileDump, licenseText) == LicenseState.Missing then
-      (insertAfterFrontmatter(fileDump, rendered), true)
-    else (fileDump, false)
-
-  /** Check for a license header after frontmatter if present. */
-  override def checkLicense(fileDump: String, licenseText: String): LicenseState =
-    val rendered      = generateLicense(licenseText)
-    val lines         = splitLines(fileDump)
-    val insertAt      = frontmatterInsertIndex(lines)
-    val expectedFirst = rendered.linesIterator.nextOption.getOrElse("")
-    val actualFirst   = lines.drop(insertAt).dropWhile(_.trim.isEmpty).headOption.getOrElse("")
-    if expectedFirst == actualFirst then LicenseState.Present
-    else if hasExternalAt(lines, insertAt) then LicenseState.External
-    else LicenseState.Missing
-
-  private def insertAfterFrontmatter(fileDump: String, rendered: String): String =
-    val lines           = splitLines(fileDump)
-    val insertAt        = frontmatterInsertIndex(lines)
-    val trimmedInsertAt = skipBlankLines(lines, insertAt)
-    val headerLines     = splitLines(rendered.stripSuffix("\n"))
-    val separator       = if insertAt > 0 then Vector("") else Vector.empty
-    val updatedLines    =
-      lines.patch(insertAt, separator ++ headerLines, trimmedInsertAt - insertAt)
-    updatedLines.mkString("\n")
-
-  private def frontmatterInsertIndex(lines: Vector[String]): Int =
-    val markerIndexes = lines.zipWithIndex.collect {
-      case (line, idx) if line.trim.startsWith("---") => idx
-    }
-    if markerIndexes.length >= 2 then markerIndexes(1) + 1 else 0
-
-  private def hasExternalAt(
-      lines: Vector[String],
-      insertAt: Int,
-      externalMarkers: Vector[String] = Vector("Copyright", "SPDX-License-Identifier"),
-      scanLines: Int = 3
-  ): Boolean =
-    val headerLines =
-      lines.drop(insertAt).dropWhile(_.trim.isEmpty).take(scanLines).map(_.trim)
-    externalMarkers.exists(marker => headerLines.exists(_.contains(marker)))
-
-  private def splitLines(text: String): Vector[String] =
-    text
-      .split("\n", -1)
-      .toVector
-      .map(line => if line.endsWith("\r") then line.dropRight(1) else line)
-
-  private def skipBlankLines(lines: Vector[String], startAt: Int): Int =
-    var idx = startAt
-    while idx < lines.length && lines(idx).trim.isEmpty do idx += 1
-    idx

--- a/src/test/resources/cases/add-all-handlers/case.yaml
+++ b/src/test/resources/cases/add-all-handlers/case.yaml
@@ -11,5 +11,6 @@ expectedOutput:
   - "Added: source/one.html"
   - "Added: source/one.astro"
   - "Added: source/one.mdx"
+  - "Added: source/one.svx"
   - "Added: source/one.cmd"
   - "Skipped: 0"

--- a/src/test/resources/cases/add-all-handlers/expected/one.svx
+++ b/src/test/resources/cases/add-all-handlers/expected/one.svx
@@ -1,0 +1,9 @@
+<!--
+SPDX-License-Identifier: MIT
+Copyright: 2026 NiceBots.xyz
+-->
+<script>
+  export let title = "demo";
+</script>
+
+# Hello

--- a/src/test/resources/cases/add-all-handlers/source/one.svx
+++ b/src/test/resources/cases/add-all-handlers/source/one.svx
@@ -1,0 +1,5 @@
+<script>
+  export let title = "demo";
+</script>
+
+# Hello

--- a/src/test/scala/CliUtilsSpec.scala
+++ b/src/test/scala/CliUtilsSpec.scala
@@ -137,16 +137,14 @@ class CliUtilsSpec extends AnyFunSuite:
     assert(!relativePaths.contains("build/output.py"), "Should exclude build/output.py")
   }
 
-  test("walker skips node_modules and .git directories") {
+  test("respect-gitignore skips paths listed in .gitignore") {
     val tempDir = Files.createTempDirectory("test")
     val srcDir  = tempDir.resolve("src")
-    val gitDir  = tempDir.resolve(".git")
     val nodeDir = tempDir.resolve("node_modules/pkg")
 
-    Files.createDirectories(gitDir)
+    Files.writeString(tempDir.resolve(".gitignore"), "node_modules/\n")
     Files.createDirectories(nodeDir)
     Files.createDirectories(srcDir)
-    Files.writeString(gitDir.resolve("config"), "git")
     Files.writeString(nodeDir.resolve("index.js"), "js")
     Files.writeString(srcDir.resolve("main.py"), "content")
 
@@ -155,7 +153,6 @@ class CliUtilsSpec extends AnyFunSuite:
     val relativePaths = result.map(_.relativeTo(baseDir).toString).sorted
 
     assert(relativePaths.contains("src/main.py"))
-    assert(!relativePaths.exists(_.contains(".git")))
     assert(!relativePaths.exists(_.contains("node_modules")))
   }
 

--- a/src/test/scala/CliUtilsSpec.scala
+++ b/src/test/scala/CliUtilsSpec.scala
@@ -137,6 +137,40 @@ class CliUtilsSpec extends AnyFunSuite:
     assert(!relativePaths.contains("build/output.py"), "Should exclude build/output.py")
   }
 
+  test("walker skips node_modules and .git directories") {
+    val tempDir = Files.createTempDirectory("test")
+    val srcDir  = tempDir.resolve("src")
+    val gitDir  = tempDir.resolve(".git")
+    val nodeDir = tempDir.resolve("node_modules/pkg")
+
+    Files.createDirectories(gitDir)
+    Files.createDirectories(nodeDir)
+    Files.createDirectories(srcDir)
+    Files.writeString(gitDir.resolve("config"), "git")
+    Files.writeString(nodeDir.resolve("index.js"), "js")
+    Files.writeString(srcDir.resolve("main.py"), "content")
+
+    val baseDir       = os.Path(tempDir)
+    val result        = CliUtils.collectFiles(Vector("**/*"), Vector.empty, baseDir)
+    val relativePaths = result.map(_.relativeTo(baseDir).toString).sorted
+
+    assert(relativePaths.contains("src/main.py"))
+    assert(!relativePaths.exists(_.contains(".git")))
+    assert(!relativePaths.exists(_.contains("node_modules")))
+  }
+
+  test("extension hints from globs reduce candidates") {
+    val tempDir = Files.createTempDirectory("test")
+    val srcDir  = tempDir.resolve("src")
+
+    Files.createDirectories(srcDir)
+    Files.writeString(srcDir.resolve("main.py"), "py")
+    Files.writeString(srcDir.resolve("readme.md"), "md")
+
+    val hints = FileWalker.extensionHintsFromGlobs(Vector("src/**/*.py"))
+    assert(hints == Set("py"))
+  }
+
   test("combining directory path and glob patterns") {
     val tempDir = Files.createTempDirectory("test")
     val srcDir  = tempDir.resolve("src")

--- a/src/test/scala/GitignoreMatcherSpec.scala
+++ b/src/test/scala/GitignoreMatcherSpec.scala
@@ -62,3 +62,37 @@ class GitignoreMatcherSpec extends AnyFunSuite:
     assert(paths.contains("vendor/lib.py"))
     assert(!paths.contains("build/out.py"))
   }
+
+  test("direct directory input respects repo-root gitignore") {
+    val tempDir = Files.createTempDirectory("gitignore")
+    Files.writeString(tempDir.resolve(".gitignore"), "src/generated/\n")
+    Files.createDirectories(tempDir.resolve("src/generated"))
+    Files.writeString(tempDir.resolve("src/generated/skip.js"), "js")
+    Files.createDirectories(tempDir.resolve("src/hand"))
+    Files.writeString(tempDir.resolve("src/hand/main.py"), "py")
+
+    val baseDir = os.Path(tempDir)
+    val result  = CliUtils.collectFiles(Vector("src"), Vector.empty, baseDir)
+    val paths   = result.map(_.relativeTo(baseDir).toString)
+
+    assert(paths.contains("src/hand/main.py"))
+    assert(!paths.exists(_.contains("generated")))
+  }
+
+  test("nested gitignore matches patterns relative to its directory") {
+    val tempDir = Files.createTempDirectory("gitignore")
+    Files.createDirectories(tempDir.resolve("src"))
+    Files.writeString(tempDir.resolve("src/.gitignore"), "generated/*.js\n")
+    Files.createDirectories(tempDir.resolve("src/generated"))
+    Files.writeString(tempDir.resolve("src/generated/a.js"), "js")
+    Files.writeString(tempDir.resolve("src/generated/a.py"), "py")
+    Files.writeString(tempDir.resolve("src/main.py"), "py")
+
+    val baseDir = os.Path(tempDir)
+    val result  = CliUtils.collectFiles(Vector("src"), Vector.empty, baseDir)
+    val paths   = result.map(_.relativeTo(baseDir).toString)
+
+    assert(paths.contains("src/main.py"))
+    assert(paths.contains("src/generated/a.py"))
+    assert(!paths.contains("src/generated/a.js"))
+  }

--- a/src/test/scala/GitignoreMatcherSpec.scala
+++ b/src/test/scala/GitignoreMatcherSpec.scala
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+// Copyright: 2026 NiceBots.xyz
+package xyz.nicebots
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.nio.file.Files
+
+class GitignoreMatcherSpec extends AnyFunSuite:
+  test("root gitignore excludes directory and its files") {
+    val tempDir = Files.createTempDirectory("gitignore")
+    Files.writeString(tempDir.resolve(".gitignore"), "node_modules/\n")
+    Files.createDirectories(tempDir.resolve("node_modules/pkg"))
+    Files.writeString(tempDir.resolve("node_modules/pkg/index.js"), "js")
+    Files.createDirectories(tempDir.resolve("src"))
+    Files.writeString(tempDir.resolve("src/main.py"), "py")
+
+    val baseDir = os.Path(tempDir)
+    val result  = CliUtils.collectFiles(Vector("**/*"), Vector.empty, baseDir)
+
+    val paths = result.map(_.relativeTo(baseDir).toString)
+    assert(paths.contains("src/main.py"))
+    assert(!paths.exists(_.contains("node_modules")))
+  }
+
+  test("no-respect-gitignore collects gitignored paths") {
+    val tempDir = Files.createTempDirectory("gitignore")
+    Files.writeString(tempDir.resolve(".gitignore"), "skipped/\n")
+    Files.createDirectories(tempDir.resolve("skipped"))
+    Files.writeString(tempDir.resolve("skipped/hidden.py"), "py")
+    Files.writeString(tempDir.resolve("visible.py"), "py")
+
+    val baseDir = os.Path(tempDir)
+    val result  =
+      CliUtils.collectFiles(Vector("*.py", "**/*.py"), Vector.empty, baseDir, respectGitignore = false)
+    val paths = result.map(_.relativeTo(baseDir).toString).sorted
+
+    assert(paths.contains("skipped/hidden.py"))
+    assert(paths.contains("visible.py"))
+  }
+
+  test("config ignores merge with CLI ignore globs") {
+    val tempDir = Files.createTempDirectory("gitignore")
+    Files.createDirectories(tempDir.resolve("vendor"))
+    Files.createDirectories(tempDir.resolve("build"))
+    Files.createDirectories(tempDir.resolve("src"))
+    Files.writeString(tempDir.resolve("vendor/lib.py"), "py")
+    Files.writeString(tempDir.resolve("build/out.py"), "py")
+    Files.createDirectories(tempDir.resolve("src"))
+    Files.writeString(tempDir.resolve("src/main.py"), "py")
+
+    val baseDir = os.Path(tempDir)
+    val result  = CliUtils.collectFiles(Vector("*.py", "**/*.py"), Vector("build/**"), baseDir)
+
+    val paths = result.map(_.relativeTo(baseDir).toString)
+    assert(paths.contains("src/main.py"))
+    assert(paths.contains("vendor/lib.py"))
+    assert(!paths.contains("build/out.py"))
+  }

--- a/src/test/scala/GitignoreMatcherSpec.scala
+++ b/src/test/scala/GitignoreMatcherSpec.scala
@@ -32,7 +32,12 @@ class GitignoreMatcherSpec extends AnyFunSuite:
 
     val baseDir = os.Path(tempDir)
     val result  =
-      CliUtils.collectFiles(Vector("*.py", "**/*.py"), Vector.empty, baseDir, respectGitignore = false)
+      CliUtils.collectFiles(
+        Vector("*.py", "**/*.py"),
+        Vector.empty,
+        baseDir,
+        respectGitignore = false
+      )
     val paths = result.map(_.relativeTo(baseDir).toString).sorted
 
     assert(paths.contains("skipped/hidden.py"))

--- a/src/test/scala/LicensingConfigSpec.scala
+++ b/src/test/scala/LicensingConfigSpec.scala
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+// Copyright: 2026 NiceBots.xyz
+package xyz.nicebots
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import config.LicensingConfig
+import config.YearRange
+
+class LicensingConfigSpec extends AnyFunSuite:
+  test("parse ignores list from YAML config") {
+    val yaml =
+      """holder: Example Corp
+        |spdx: MIT
+        |year: 2026
+        |ignores:
+        |  - vendor/**
+        |  - build/**
+        |""".stripMargin
+
+    LicensingConfig.parse(yaml) match
+      case Right(config) =>
+        assert(config.holder == "Example Corp")
+        assert(config.spdxId.contains("MIT"))
+        assert(config.years == YearRange.Single(2026))
+        assert(config.ignores == Vector("vendor/**", "build/**"))
+      case Left(err) => fail(err)
+  }
+
+  test("missing ignores field defaults to empty vector") {
+    val yaml =
+      """holder: Example Corp
+        |year: 2026
+        |""".stripMargin
+
+    LicensingConfig.parse(yaml) match
+      case Right(config) => assert(config.ignores.isEmpty)
+      case Left(err)     => fail(err)
+  }
+
+  test("invalid ignores field returns error") {
+    val yaml =
+      """holder: Example Corp
+        |year: 2026
+        |ignores: vendor/**
+        |""".stripMargin
+
+    LicensingConfig.parse(yaml) match
+      case Right(_)  => fail("Expected parse error for non-list ignores")
+      case Left(err) => assert(err.contains("ignores"))
+  }

--- a/src/test/scala/LineParsingSpec.scala
+++ b/src/test/scala/LineParsingSpec.scala
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+// Copyright: 2026 NiceBots.xyz
+package xyz.nicebots
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class LineParsingSpec extends AnyFunSuite:
+  test("frontmatterInsertIndex finds closing marker") {
+    val lines = Vector("---", "title: x", "---", "", "body")
+    assert(LineParsing.frontmatterInsertIndex(lines) == 3)
+  }
+
+  test("hasExternalAt detects SPDX after frontmatter") {
+    val lines = Vector("---", "a: 1", "---", "", "SPDX-License-Identifier: Apache-2.0")
+    assert(LineParsing.hasExternalAt(lines, LineParsing.frontmatterInsertIndex(lines)))
+  }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds `FileWalker` with symlink-safe traversal and extension-hint prefiltering for globs.
- **Ignore sources (merged):**
  - `.gitignore` files (default, via `--respect-gitignore`; disable with `--no-respect-gitignore`)
  - `ignores:` list in `licensor-config.yaml`
  - CLI `--ignore` globs
- Refactors frontmatter handlers and improves full-header license matching.
- Adds strict UTF-8 reads and `.svx` (MDsveX) support.

Closes #12.

## Breaking changes

- License presence detection requires the full rendered header block (not just the first line).
- File collection no longer uses a hardcoded skip list (`node_modules`, `.git`, etc.); use `.gitignore` or explicit `ignores` instead.

## Test plan

- [x] `sbt scalafmtCheckAll`
- [x] `sbt scalafixAll --check`
- [x] `sbt test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1f076de-ff4a-4f13-a77d-32f31c807ca4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1f076de-ff4a-4f13-a77d-32f31c807ca4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

